### PR TITLE
worker handle_exception should not require a message on the exception

### DIFF
--- a/lib/ant/worker.ex
+++ b/lib/ant/worker.ex
@@ -174,7 +174,7 @@ defmodule Ant.Worker do
 
     error = %{
       attempt: attempts,
-      error: exception.message,
+      error: Map.get(exception, :message, inspect(exception)),
       stack_trace: Exception.format_stacktrace(stack_trace),
       attempted_at: DateTime.utc_now()
     }


### PR DESCRIPTION
This is a dupe of the PR on the the library's source, so I don't need to wait around for that to get merged in.

https://github.com/MikeAndrianov/ant/pull/3